### PR TITLE
type inference gets smarter

### DIFF
--- a/packages/parser/src/core.ts
+++ b/packages/parser/src/core.ts
@@ -310,7 +310,7 @@ export class ZoneParser {
             throw new SyntaxError(`${l.token} is not domain at ${l.line}:${l.column}`);
           }
           const rr: CNAME = {
-            hdr,
+            hdr: hdr as RrHeader<Rrtype.CNAME>,
             target
           }
           return rr;
@@ -332,7 +332,7 @@ export class ZoneParser {
           }
           const os = lx.token;
           const rr: HINFO = {
-            hdr,
+            hdr: hdr as RrHeader<Rrtype.HINFO>,
             cpu,
             os
           }
@@ -361,7 +361,7 @@ export class ZoneParser {
             throw new SyntaxError(`${m.token} is not domain at ${m.line}:${m.column}`);
           }
           const rr: MX = {
-            hdr,
+            hdr: hdr as RrHeader<Rrtype.MX>,
             preference,
             mx,
           }
@@ -378,7 +378,7 @@ export class ZoneParser {
             throw new SyntaxError(`${l.token} is not domain at ${l.line}:${l.column}`);
           }
           const rr: NS = {
-            hdr,
+            hdr: hdr as RrHeader<Rrtype.NS>,
             ns
           }
           return rr;
@@ -394,7 +394,7 @@ export class ZoneParser {
             throw new SyntaxError(`${l.token} is not domain at ${l.line}:${l.column}`);
           }
           const rr: PTR = {
-            hdr,
+            hdr: hdr as RrHeader<Rrtype.PTR>,
             ptr
           }
           return rr;
@@ -421,7 +421,7 @@ export class ZoneParser {
 
 
           const rr: SOA = {
-            hdr,
+            hdr: hdr as RrHeader<Rrtype.SOA>,
             ns,
             mbox,
             serial: 0,
@@ -495,7 +495,7 @@ export class ZoneParser {
             throw new SyntaxError('arguments is too many');
           }
           const rr: TXT = {
-            hdr,
+            hdr: hdr as RrHeader<Rrtype.TXT>,
             txt: txt[0],
           }
           return rr;
@@ -509,7 +509,7 @@ export class ZoneParser {
           }
           const a = l.token;
           const rr: A = {
-            hdr,
+            hdr: hdr as RrHeader<Rrtype.A>,
             a,
           }
           return rr;

--- a/packages/parser/src/types.ts
+++ b/packages/parser/src/types.ts
@@ -20,58 +20,49 @@ export enum Class {
 
 export interface TTLState {
   ttl: number;
-  isByDirective: boolean
+  isByDirective: boolean;
 }
 
-export interface RrHeader {
+export interface RrHeader<T = Rrtype> {
   name: string;
-  rrtype: Rrtype;
+  rrtype: T;
   class: Class;
   ttl: number;
 }
 
-export type RR =
-  CNAME |
-  HINFO |
-  MX |
-  NS |
-  PTR |
-  SOA |
-  TXT |
-  A;
+export type RR = CNAME | HINFO | MX | NS | PTR | SOA | TXT | A;
 
 export interface CNAME {
-  hdr: RrHeader;
+  hdr: RrHeader<Rrtype.CNAME>;
   target: string;
 }
 
 export interface HINFO {
-  hdr: RrHeader;
+  hdr: RrHeader<Rrtype.HINFO>;
   cpu: string;
   os: string;
 }
 
 export interface MX {
-  hdr: RrHeader;
+  hdr: RrHeader<Rrtype.MX>;
   preference: number;
   mx: string;
 }
 
 export interface NS {
-  hdr: RrHeader;
+  hdr: RrHeader<Rrtype.NS>;
   ns: string;
 }
 
 export interface PTR {
-  hdr: RrHeader;
+  hdr: RrHeader<Rrtype.PTR>;
   ptr: string;
 }
 
-
 export interface SOA {
-  hdr: RrHeader;
+  hdr: RrHeader<Rrtype.SOA>;
   ns: string;
-  mbox: string
+  mbox: string;
   serial: number;
   refresh: number;
   retry: number;
@@ -80,15 +71,14 @@ export interface SOA {
 }
 
 export interface TXT {
-  hdr: RrHeader;
+  hdr: RrHeader<Rrtype.TXT>;
   txt: string;
 }
 
 export interface A {
-  hdr: RrHeader;
+  hdr: RrHeader<Rrtype.A>;
   a: string;
 }
-
 
 export interface Lex {
   token: string;
@@ -126,5 +116,5 @@ export enum Tokenize {
   zExpectDirTTLBl,
   zExpectDirTTL,
   zExpectDirOriginBl,
-  zExpectDirOrigin,
+  zExpectDirOrigin
 }


### PR DESCRIPTION
```ts
const rr: RR = ... ;
switch(rr.hdr.rrtypes) {
  case Rrtype.CNAME:
    // `rr` type is inferred that it is `CNAME` 
}
```