### PR TITLE
init core

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,0 +1,3 @@
+## @dzfu/core
+
+dns zonefile core

--- a/packages/core/__tests__/normal.spec.ts
+++ b/packages/core/__tests__/normal.spec.ts
@@ -1,0 +1,40 @@
+import { isRrtype, toRrtype, isClass, toClass, Rrtype, Class } from '../src';
+
+describe('normal scenario', () => {
+  it('isRrtype', () => {
+    expect(isRrtype('CNAME')).toEqual(Rrtype.CNAME);
+    expect(isRrtype('HINFO')).toEqual(Rrtype.HINFO);
+    expect(isRrtype('MX')).toEqual(Rrtype.MX);
+    expect(isRrtype('NS')).toEqual(Rrtype.NS);
+    expect(isRrtype('PTR')).toEqual(Rrtype.PTR);
+    expect(isRrtype('SOA')).toEqual(Rrtype.SOA);
+    expect(isRrtype('TXT')).toEqual(Rrtype.TXT);
+    expect(isRrtype('A')).toEqual(Rrtype.A);
+  });
+  it('toRrtype', () => {
+    expect(toRrtype(Rrtype.CNAME)).toEqual('CNAME');
+    expect(toRrtype(Rrtype.HINFO)).toEqual('HINFO');
+    expect(toRrtype(Rrtype.MX)).toEqual('MX');
+    expect(toRrtype(Rrtype.NS)).toEqual('NS');
+    expect(toRrtype(Rrtype.PTR)).toEqual('PTR');
+    expect(toRrtype(Rrtype.SOA)).toEqual('SOA');
+    expect(toRrtype(Rrtype.TXT)).toEqual('TXT');
+    expect(toRrtype(Rrtype.A)).toEqual('A');
+  });
+  it('isClass', () => {
+    expect(isClass('IN')).toEqual(Class.IN);
+    expect(isClass('CS')).toEqual(Class.CS);
+    expect(isClass('CH')).toEqual(Class.CH);
+    expect(isClass('HS')).toEqual(Class.HS);
+    expect(isClass('NONE')).toEqual(Class.NONE);
+    expect(isClass('ANY')).toEqual(Class.ANY);
+  });
+  it('toClass', () => {
+    expect(toClass(Class.IN)).toEqual('IN');
+    expect(toClass(Class.CS)).toEqual('CS');
+    expect(toClass(Class.CH)).toEqual('CH');
+    expect(toClass(Class.HS)).toEqual('HS');
+    expect(toClass(Class.NONE)).toEqual('NONE');
+    expect(toClass(Class.ANY)).toEqual('ANY');
+  });
+});

--- a/packages/core/__tests__/tsconfig.json
+++ b/packages/core/__tests__/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../../tsconfig.json",
+  "target": "es6",
+  "module": "commonjs",
+  // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
+  /* Strict Type-Checking Options */
+  "strict": true,
+  "resolveJsonModule": true,
+  "esModuleInterop": true
+}

--- a/packages/core/jest.config.js
+++ b/packages/core/jest.config.js
@@ -1,0 +1,14 @@
+module.exports = {
+  roots: ['./'],
+  transform: {
+    '^.+\\.ts$': 'ts-jest'
+  },
+  globals: {
+    'ts-jest': {
+      tsConfig: '__tests__/tsconfig.json'
+    }
+  },
+  preset: 'ts-jest',
+  testRegex: '(/__tests__/.*|(\\.|/)(test|spec))\\.ts$',
+  moduleFileExtensions: ['ts', 'js', 'json', 'node']
+};

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "@dzfu/core",
+  "description": "dns zone file core",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/KoyamaSohei/dzfu.git"
+  },
+  "keywords": [
+    "dns",
+    "zonefine"
+  ],
+  "types": "lib/index.d.ts",
+  "version": "0.0.2",
+  "author": "KoyamaSohei <koyamaso0309@gmail.com>",
+  "license": "MIT",
+  "main": "lib/core.umd.js",
+  "module": "lib/core.es5.js",
+  "directories": {
+    "lib": "lib",
+    "test": "__tests__"
+  },
+  "files": [
+    "lib"
+  ],
+  "scripts": {
+    "build": "rollup -c rollup.config.js && typedoc --out docs --target es6 --theme minimal --mode file src",
+    "test": "jest --coverage --silent=false"
+  },
+  "devDependencies": {
+    "@types/jest": "^24.0.15",
+    "@typescript-eslint/eslint-plugin": "^1.11.0",
+    "@typescript-eslint/parser": "^1.11.0",
+    "eslint": "^6.0.1",
+    "eslint-config-prettier": "^6.0.0",
+    "eslint-plugin-prettier": "^3.1.0",
+    "jest": "^24.8.0",
+    "prettier": "^1.18.2",
+    "rollup": "^1.16.6",
+    "rollup-plugin-commonjs": "^10.0.1",
+    "rollup-plugin-node-resolve": "^5.2.0",
+    "rollup-plugin-sourcemaps": "^0.4.2",
+    "rollup-plugin-typescript2": "^0.21.2",
+    "ts-jest": "^24.0.2",
+    "typescript": "^3.5.2"
+  }
+}

--- a/packages/core/rollup.config.js
+++ b/packages/core/rollup.config.js
@@ -1,0 +1,23 @@
+import resolve from 'rollup-plugin-node-resolve';
+import commonjs from 'rollup-plugin-commonjs';
+import sourceMaps from 'rollup-plugin-sourcemaps';
+import typescript from 'rollup-plugin-typescript2';
+import pkg from './package.json';
+
+export default {
+  input: 'src/index.ts',
+  output: [
+    { file: pkg.main, name: 'core', format: 'umd', sourcemap: true },
+    { file: pkg.module, format: 'es', sourcemap: true }
+  ],
+  external: [],
+  watch: {
+    include: 'src/**'
+  },
+  plugins: [
+    typescript({ useTsconfigDeclarationDir: true }),
+    commonjs(),
+    resolve(),
+    sourceMaps()
+  ]
+};

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,0 +1,82 @@
+import { Rrtype, Class } from './types';
+export { Rrtype, Class };
+
+export function isRrtype(t: string) {
+  switch (t) {
+    case 'CNAME':
+      return Rrtype.CNAME;
+    case 'HINFO':
+      return Rrtype.HINFO;
+    case 'MX':
+      return Rrtype.MX;
+    case 'NS':
+      return Rrtype.NS;
+    case 'PTR':
+      return Rrtype.PTR;
+    case 'SOA':
+      return Rrtype.SOA;
+    case 'TXT':
+      return Rrtype.TXT;
+    case 'A':
+      return Rrtype.A;
+    default:
+      return null;
+  }
+}
+
+export function toRrtype(t: Rrtype): string {
+  switch (t) {
+    case Rrtype.CNAME:
+      return 'CNAME';
+    case Rrtype.HINFO:
+      return 'HINFO';
+    case Rrtype.MX:
+      return 'MX';
+    case Rrtype.NS:
+      return 'NS';
+    case Rrtype.PTR:
+      return 'PTR';
+    case Rrtype.SOA:
+      return 'SOA';
+    case Rrtype.TXT:
+      return 'TXT';
+    case Rrtype.A:
+      return 'A';
+  }
+}
+
+export function isClass(c: string) {
+  switch (c) {
+    case 'IN':
+      return Class.IN;
+    case 'CS':
+      return Class.CS;
+    case 'CH':
+      return Class.CH;
+    case 'HS':
+      return Class.HS;
+    case 'NONE':
+      return Class.NONE;
+    case 'ANY':
+      return Class.ANY;
+    default:
+      return null;
+  }
+}
+
+export function toClass(c: Class) {
+  switch (c) {
+    case Class.IN:
+      return 'IN';
+    case Class.CS:
+      return 'CS';
+    case Class.CH:
+      return 'CH';
+    case Class.HS:
+      return 'HS';
+    case Class.NONE:
+      return 'NONE';
+    case Class.ANY:
+      return 'ANY';
+  }
+}

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,0 +1,68 @@
+export enum Rrtype {
+  CNAME,
+  HINFO,
+  MX,
+  NS,
+  PTR,
+  SOA,
+  TXT,
+  A
+}
+
+export enum Class {
+  IN,
+  CS,
+  CH,
+  HS,
+  NONE,
+  ANY
+}
+
+export interface RrHeader<T extends Rrtype = Rrtype> {
+  name: string;
+  rrtype: T;
+  class: Class;
+  ttl: number;
+}
+
+export type RR = CNAME | HINFO | MX | NS | PTR | SOA | TXT | A;
+
+export type CNAME = RrHeader<Rrtype.CNAME> & {
+  target: string;
+};
+
+export type HINFO = RrHeader<Rrtype.HINFO> & {
+  cpu: string;
+  os: string;
+};
+
+export type MX = RrHeader<Rrtype.MX> & {
+  preference: number;
+  mx: string;
+};
+
+export type NS = RrHeader<Rrtype.NS> & {
+  ns: string;
+};
+
+export type PTR = RrHeader<Rrtype.PTR> & {
+  ptr: string;
+};
+
+export type SOA = RrHeader<Rrtype.SOA> & {
+  ns: string;
+  mbox: string;
+  serial: number;
+  refresh: number;
+  retry: number;
+  expire: number;
+  minttl: number;
+};
+
+export type TXT = RrHeader<Rrtype.TXT> & {
+  txt: string;
+};
+
+export type A = RrHeader<Rrtype.A> & {
+  a: string;
+};

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "declarationDir": "./lib"
+  },
+  "include": ["./src"]
+}


### PR DESCRIPTION
move core function (e.g. Rrtypes, enum <-> string transformer, that other package will use) to @dzfu/core.